### PR TITLE
getRouteUrl method changed

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -266,7 +266,7 @@ class Grid extends GridTools
             return $this->routeforced;
         } else {
             return $currentUrl = $this->request->getUri();
-	}
+        }
     }
 
     public function setRouteForced($route)
@@ -311,7 +311,7 @@ class Grid extends GridTools
     {
         return $this->subGrid;
     }
-    
+
     /**
      * @return \Doctrine\ORM\QueryBuilder
      */
@@ -319,8 +319,8 @@ class Grid extends GridTools
     {
         return $this->qb;
     }
-    
-    
+
+
 
     public function render()
     {

--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -265,8 +265,8 @@ class Grid extends GridTools
         if ($this->routeforced != '') {
             return $this->routeforced;
         } else {
-            return $this->router->generate($this->request->get('_route'));
-        }
+            return $currentUrl = $this->request->getUri();
+	}
     }
 
     public function setRouteForced($route)


### PR DESCRIPTION
Using 

``` php
$this->router->generate($this->request->get('_route'));
```

to get the current URL I always got errors with missing URL parameters:

```
The "xyz" route has some missing mandatory parameters 
```

My fork uses 

``` php
$this->request->getUri();
```

which avoids this problem.
